### PR TITLE
make custom prop types optional by default

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,6 +16,6 @@ export type JSXFactory<TSprinkleFn extends SprinkleFn, TCustomProps> = Record<
       children?: ReactNode
     } & HTMLProps<TProps> &
       EscapedCSSProperties<CSSProperties> &
-      TCustomProps
+      Partial<TCustomProps>
   ) => JSX.Element
 >


### PR DESCRIPTION
make custom prop types passed to `createFactory` fn optional by default