### PR TITLE
feat: add reverse condition support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,16 @@
 {
   "name": "sprinkled-react",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sprinkled-react",
-      "version": "0.0.2",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "react-fast-compare": "^3.2.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
@@ -6490,6 +6494,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -12118,6 +12127,11 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "vanilla extract sprinkles",
     "vanilla extract react",
     "sprinkled react"
-  ]
+  ],
+  "dependencies": {
+    "react-fast-compare": "^3.2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   ],
   "dependencies": {
     "react-fast-compare": "^3.2.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0"
   }
 }

--- a/src/__tests__/sprinkled-react-test.tsx
+++ b/src/__tests__/sprinkled-react-test.tsx
@@ -146,4 +146,33 @@ describe('Sprinkled React element tests', () => {
     expect(elem).toHaveFocus()
     expect(elem).toHaveStyle({ margin: '16px' })
   })
+
+  test('Skips property if corresponding token is an array', () => {
+    function Comp() {
+      const inputRef = React.useRef<HTMLInputElement>(null)
+
+      React.useEffect(() => {
+        if (inputRef.current) {
+          inputRef.current.focus()
+        }
+      }, [])
+
+      return (
+        <s.input
+          type="text"
+          placeholder="your-name"
+          ref={inputRef}
+          m={['md']}
+          _f={{ m: 'lg' }}
+        />
+      )
+    }
+
+    const { getByPlaceholderText } = render(<Comp />)
+
+    const elem = getByPlaceholderText('your-name')
+
+    expect(elem).toHaveFocus()
+    expect(elem).toHaveStyle({ margin: '8px' })
+  })
 })

--- a/src/__tests__/sprinkled-react-test.tsx
+++ b/src/__tests__/sprinkled-react-test.tsx
@@ -118,4 +118,32 @@ describe('Sprinkled React element tests', () => {
 
     expect(elem).toHaveAttribute('type', 'submit')
   })
+
+  test('Accepts reversed condition props', () => {
+    function Comp() {
+      const inputRef = React.useRef<HTMLInputElement>(null)
+
+      React.useEffect(() => {
+        if (inputRef.current) {
+          inputRef.current.focus()
+        }
+      }, [])
+
+      return (
+        <s.input
+          type="text"
+          placeholder="your-name"
+          ref={inputRef}
+          _f={{ m: 'lg' }}
+        />
+      )
+    }
+
+    const { getByPlaceholderText } = render(<Comp />)
+
+    const elem = getByPlaceholderText('your-name')
+
+    expect(elem).toHaveFocus()
+    expect(elem).toHaveStyle({ margin: '16px' })
+  })
 })

--- a/src/__tests__/test-utils/index.tsx
+++ b/src/__tests__/test-utils/index.tsx
@@ -11,6 +11,10 @@ type CustomElementProps = {
 
 export const s = createFactory({
   sprinkles,
+  reverseConditions: {
+    default: 'default',
+    f: 'focus'
+  },
   customElement: ({ element, classes, props }: CustomElementProps) => {
     if (element === 'Button') {
       return (

--- a/src/__tests__/test-utils/sprinkles.css.ts
+++ b/src/__tests__/test-utils/sprinkles.css.ts
@@ -30,7 +30,8 @@ const props = defineProperties({
     default: {},
     focus: { selector: '&:focus' }
   },
-  defaultCondition: 'default'
+  defaultCondition: 'default',
+  responsiveArray: ['default', 'focus']
 })
 
 export const sprinkles = createSprinkles(props)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,19 @@
-import { createElement, forwardRef } from 'react'
+import { createElement, forwardRef, memo } from 'react'
+import isEqual from 'react-fast-compare'
 
 import { extractProps } from './utils'
 import type { SprinkleFn, JSXFactory } from './utils'
 
 export function createFactory<
   TSprinkleFn extends SprinkleFn,
-  TCustomProps = {}
+  TCustomProps = {},
+  TReverseCondtions extends { default: string; [x: string]: string } = {
+    default: ''
+  }
 >({
   sprinkles,
-  customElement
+  customElement,
+  reverseConditions
 }: {
   sprinkles: TSprinkleFn
   customElement?: (arg: {
@@ -16,33 +21,40 @@ export function createFactory<
     classes: string
     props: any
   }) => JSX.Element | null | undefined
+  reverseConditions?: TReverseCondtions
 }) {
-  return new Proxy<JSXFactory<TSprinkleFn, TCustomProps>>(
+  return new Proxy<JSXFactory<TSprinkleFn, TCustomProps, TReverseCondtions>>(
     {},
     {
       get: (_: unknown, element: string) => {
-        return forwardRef<Parameters<TSprinkleFn>[0]>((props, ref) => {
-          const { sprinkleProps, otherProps, style, className } = extractProps(
-            props,
-            sprinkles
-          )
-          const classes = sprinkles(sprinkleProps)
+        return memo(
+          forwardRef<Parameters<TSprinkleFn>[0]>((props, ref) => {
+            const { sprinkleProps, otherProps, style, className } =
+              extractProps(props, sprinkles, reverseConditions)
+            const classes = sprinkles(sprinkleProps)
 
-          const userElement = customElement
-            ? customElement({ element, classes, props })
-            : null
+            const userElement = customElement
+              ? customElement({ element, classes, props })
+              : null
 
-          if (userElement) {
-            return userElement
+            if (userElement) {
+              return userElement
+            }
+
+            return createElement(element, {
+              ref,
+              className: `${classes} ${className}`.trim(),
+              style,
+              ...otherProps
+            })
+          }),
+          // Since `extractProps` fn performs some heavy calculation
+          // we will memoize each component and will only rerender if
+          // the props have changed.
+          (prevProps: any, nextProps: any) => {
+            return isEqual(prevProps, nextProps)
           }
-
-          return createElement(element, {
-            ref,
-            className: `${classes} ${className}`.trim(),
-            style,
-            ...otherProps
-          })
-        })
+        )
       }
     }
   )

--- a/src/utils/extract-props.ts
+++ b/src/utils/extract-props.ts
@@ -40,7 +40,7 @@ export function extractProps(
             [reverseLookup.default]: sprinkleProps[key],
             [condition.name]: condition.values[key]
           }
-        } else {
+        } else if(!Array.isArray(sprinkleProps[key])) {
           sprinkleProps[key][condition.name] = condition.values[key]
         }
       } else {

--- a/src/utils/extract-props.ts
+++ b/src/utils/extract-props.ts
@@ -1,20 +1,57 @@
 export function extractProps(
   { className = '', style = {}, ...props }: Record<string, any>,
-  sprinkles: any
+  sprinkles: any,
+  reverseLookup: any = {}
 ) {
   let sprinkleProps: Record<string, any> = {}
   let escapedStyles: Record<string, any> = {}
   let otherProps: Record<string, any> = {}
 
+  let conditionProps = []
+
+  // Divide props to their appropriate position.
   for (let key in props) {
     if (sprinkles.properties.has(key)) {
+      // Initial sprinkled props but will get modified later.
       sprinkleProps[key] = props[key]
+    } else if (key[0] === '_' && key[1] !== '_') {
+      // Push all condition props in an array for now.
+      conditionProps.push({
+        name: reverseLookup[key.substring(1)],
+        keys: Object.keys(props[key]),
+        values: props[key]
+      })
     } else if (key.startsWith('__')) {
+      // Escaped styles which will be assigned to `style` prop later.
       escapedStyles[key.substring(2)] = props[key]
     } else {
+      // Props that we don't need
       otherProps[key] = props[key]
     }
   }
+
+  // Assign each reverse condition props by modifying `sprinkleProps`
+  conditionProps.forEach(condition => {
+    condition.keys.forEach(key => {
+      // If prop for specified condition is available update it.
+      if (key in sprinkleProps) {
+        if (typeof sprinkleProps[key] !== 'object') {
+          sprinkleProps[key] = {
+            [reverseLookup.default]: sprinkleProps[key],
+            [condition.name]: condition.values[key]
+          }
+        } else {
+          sprinkleProps[key][condition.name] = condition.values[key]
+        }
+      } else {
+        // If prop for specified condition is not available make it.
+        sprinkleProps[key] = {
+          [reverseLookup.default]: undefined,
+          [condition.name]: condition.values[key]
+        }
+      }
+    })
+  })
 
   style = { ...style, ...escapedStyles }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,14 +8,27 @@ export type SprinkleFn = {
 type EscapedCSSProperties<TCSSPRroperties> = {
   [Key in keyof TCSSPRroperties as `__${string & Key}`]: TCSSPRroperties[Key]
 }
+type ReversedConditionProps<TConditionProps, SprinkleProps> = {
+  [Key in keyof TConditionProps as `_${string & Key}`]: SprinkleProps
+}
 
-export type JSXFactory<TSprinkleFn extends SprinkleFn, TCustomProps> = Record<
+export type JSXFactory<
+  TSprinkleFn extends SprinkleFn,
+  TCustomProps,
+  TConditionProps
+> = Record<
   string,
   <TProps>(
     prop: Parameters<TSprinkleFn>[0] & {
       children?: ReactNode
     } & HTMLProps<TProps> &
       EscapedCSSProperties<CSSProperties> &
+      Partial<
+        ReversedConditionProps<
+          Omit<TConditionProps, 'default'>,
+          Parameters<TSprinkleFn>[0]
+        >
+      > &
       Partial<TCustomProps>
   ) => JSX.Element
 >


### PR DESCRIPTION
## Configuration
```ts
export const s = createFactory({
        sprinkles: sprinklesFn,
        reverseConditions: {
            default: 'default',
            f: 'focus',
            h: 'hover'
      }
})
```
## Usage
```ts
    <s.button 
       borderColor='#000'
       color='#FFF' 
       backgroundColor='#000' 
       _h={{ color: '#000', backgroundColor: '#FFF' }}  // reverse condition for `hover`
      > 
       Submit
    </s.button>
```